### PR TITLE
[WINDUP-3270] - Upgrade MTA Web to use EAP 7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <name>Windup Web - Keycloak Tool</name>
 
     <properties>
-        <version.keycloak>8.0.1</version.keycloak>
-        <version.resteasy>3.0.14.Final</version.resteasy>
+        <version.keycloak>15.1.1</version.keycloak>
+        <version.resteasy>3.15.1.Final</version.resteasy>
         <windup.scm.connection>scm:git:https://github.com/windup/windup-keycloak-tool.git</windup.scm.connection>
         <windup.developer.connection>scm:git:git@github.com:windup/windup-keycloak-tool.git</windup.developer.connection>
         <windup.scm.url>http://github.com/windup/windup-keycloak-tool</windup.scm.url>

--- a/src/main/resources/windup-realm/windup-realm.json
+++ b/src/main/resources/windup-realm/windup-realm.json
@@ -1,7 +1,7 @@
 {
   "id": "mta",
   "realm": "mta",
-  "displayName": "Tackle Analysis Web Console",
+  "displayName": "Migration Toolkit for Applications Web Console",
   "notBefore": 0,
   "revokeRefreshToken": false,
   "accessTokenLifespan": 300,
@@ -779,7 +779,7 @@
     {
       "id": "739a78cd-ab8d-427a-93f7-4af38f0eab31",
       "clientId": "mta-web",
-      "name": "Tackle Analysis Web Console",
+      "name": "Migration Toolkit for Applications Web Console",
       "surrogateAuthRequired": false,
       "enabled": true,
       "clientAuthenticatorType": "client-secret",

--- a/src/main/resources/windup-realm/windup-realm.json
+++ b/src/main/resources/windup-realm/windup-realm.json
@@ -1,7 +1,7 @@
 {
   "id": "mta",
   "realm": "mta",
-  "displayName": "Migration Toolkit for Applications Web Console",
+  "displayName": "Tackle Analysis Web Console",
   "notBefore": 0,
   "revokeRefreshToken": false,
   "accessTokenLifespan": 300,
@@ -779,7 +779,7 @@
     {
       "id": "739a78cd-ab8d-427a-93f7-4af38f0eab31",
       "clientId": "mta-web",
-      "name": "Migration Toolkit for Applications Web Console",
+      "name": "Tackle Analysis Web Console",
       "surrogateAuthRequired": false,
       "enabled": true,
       "clientAuthenticatorType": "client-secret",


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3270
- Upgraded Keycloak and Resteasy version.
- Resteasy version taken from https://access.redhat.com/articles/112673#EAP_7